### PR TITLE
Copy include files to installation directory.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,6 +225,10 @@ install(TARGETS ${PROJECT_NAME}
             ARCHIVE DESTINATION lib
             LIBRARY DESTINATION lib)
 
+# Install include directories too.
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/nana
+        DESTINATION include)
+
 set_property( TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 14 )
 
 # TODO: move this nana-demo section to the nana demo repository, and here only include that cmake file

--- a/include/nana/filesystem/filesystem_selector.hpp
+++ b/include/nana/filesystem/filesystem_selector.hpp
@@ -60,6 +60,8 @@ namespace std {
 	} // experimental
 } // std
 
+#elif (__GNUC__)
+#    include <experimental/filesystem>
 #else
 #    include <filesystem>
 #endif


### PR DESCRIPTION
Users of the Nana library should depend only on the installation directory.  I'm not sure if any include files could be excluded, so I simply took them all.
